### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Source: https://github.com/rbrito/avr-evtd
 
 Files: *
 Copyright: 2006 Bob Perry <lb-source@users.sourceforge.net>
-	   2008-2020 Rogério Theodoro de Brito <rbrito@ime.usp.br>
+           2008-2020 Rogério Theodoro de Brito <rbrito@ime.usp.br>
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/rbrito/avr-evtd/issues
+Bug-Submit: https://github.com/rbrito/avr-evtd/issues/new
+Repository: https://github.com/rbrito/avr-evtd.git
+Repository-Browse: https://github.com/rbrito/avr-evtd


### PR DESCRIPTION
Fix some issues reported by lintian

* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/avr-evtd/49baf766-823d-4300-874e-2d6ffac82ed7.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a0/8c7b564590b8d16aeb82acf3cfda163dbbb4f7.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b3/3b96ec220da6d9538b2ca87804edf54d8ae623.debug

No differences were encountered between the control files of package \*\*avr-evtd\*\*
### Control files of package avr-evtd-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-b33b96ec220da6d9538b2ca87804edf54d8ae623-] {+a08c7b564590b8d16aeb82acf3cfda163dbbb4f7+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/49baf766-823d-4300-874e-2d6ffac82ed7/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/49baf766-823d-4300-874e-2d6ffac82ed7/diffoscope)).
