### PR TITLE
Move package to the QA team

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: avr-evtd
 Section: misc
 Priority: optional
-Maintainer: Rogério Theodoro de Brito <rbrito@ime.usp.br>
+Maintainer: Debian QA Group <packages@qa.debian.org>
 Build-Depends:
  debhelper-compat (= 13),
 Standards-Version: 4.1.5


### PR DESCRIPTION
Move orphaned package to the QA team.

For details, see the [orphan bug](https://bugs.debian.org/994655).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/orphan), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/orphan/pkg/avr-evtd/89537bb5-26ea-4752-a12e-6e993d2db79a.