### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -4,7 +4,7 @@ Source: https://github.com/rbrito/avr-evtd
 
 Files: *
 Copyright: 2006 Bob Perry <lb-source@users.sourceforge.net>
-	   2008-2020 Rogério Theodoro de Brito <rbrito@ime.usp.br>
+           2008-2020 Rogério Theodoro de Brito <rbrito@ime.usp.br>
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+---
+Bug-Database: https://github.com/rbrito/avr-evtd/issues
+Bug-Submit: https://github.com/rbrito/avr-evtd/issues/new
+Repository-Browse: https://github.com/rbrito/avr-evtd


### PR DESCRIPTION
Fix some issues reported by lintian

* debian/copyright: use spaces rather than tabs to start continuation lines. ([tab-in-license-text](https://lintian.debian.org/tags/tab-in-license-text))

* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/avr-evtd/8db66775-e9e8-43c7-96de-d1f29c0b0874.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/cd/ed99ddd9547aff1f97bec928d5bad0317197df.debug
    -rwxr-xr-x  root/root   DEBIAN/preinst
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/d2/bedcb007832407a0c027e920db8f0d29c03484.debug

No differences were encountered between the control files of package \*\*avr-evtd\*\*
### Control files of package avr-evtd-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-d2bedcb007832407a0c027e920db8f0d29c03484-] {+cded99ddd9547aff1f97bec928d5bad0317197df+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/8db66775-e9e8-43c7-96de-d1f29c0b0874/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/8db66775-e9e8-43c7-96de-d1f29c0b0874/diffoscope)).
